### PR TITLE
Feature/jdk 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN rbenv global 2.6.5
 RUN gem install bundler:2.1.4
 
 ## Install Android SDK
-ARG sdk_version=sdk-tools-linux-4333796.zip
+ARG sdk_version=commandlinetools-linux-6200805_latest.zip
 ARG android_home=/opt/android/sdk
 RUN mkdir -p ${android_home} && \
     wget --quiet --output-document=/tmp/${sdk_version} https://dl.google.com/android/repository/${sdk_version} && \
@@ -54,11 +54,8 @@ ENV PATH=${ANDROID_HOME}/emulator:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bi
 
 RUN mkdir ~/.android && echo '### User Sources for Android SDK Manager' > ~/.android/repositories.cfg
 
-RUN yes | sdkmanager --licenses && yes | sdkmanager --update
-
-# Update SDK manager and install system image, platform and build tools
-RUN sdkmanager \
-  "tools" \
+RUN yes | sdkmanager --sdk_root=$ANDROID_HOME --licenses
+RUN sdkmanager --sdk_root=$ANDROID_HOME --install \
   "platform-tools" \
   "build-tools;29.0.2" \
   "platforms;android-29"


### PR DESCRIPTION
Fix #6 . Update to jdk 11 has some impacts. `sdkmanager` was no able to be setup through jdk > 8 until 26 March 2020 ([yesterday when opening this PR!](https://issuetracker.google.com/issues/67495440)). To use the new `sdkmanager` we have to tweak its setup.