### PR TITLE
Cleanup desc script formatting

### DIFF
--- a/desc/desc.sh
+++ b/desc/desc.sh
@@ -9,8 +9,13 @@ echo "### Android SDKs"
 sdkmanager --list --sdk_root=$ANDROID_HOME |
     awk '/Installed packages:/{flag=1; next} /Available Packages/{flag=0} flag'
 echo "### Google Cloud SDK"
-gcloud --version
-echo
+echo "| Name | Version |"
+echo "|------|---------|"
+gcloud --version | while read -r lib; do
+    version=$(echo "${lib}" | awk '{ print $NF }')
+    name=$(echo $lib | awk '{$NF=""; print $0}')
+    echo "| $name | $version |"
+done
 
 echo "## APT packages"
 dpkg -l

--- a/desc/desc.sh
+++ b/desc/desc.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 echo "## Image environment"
 grep "DISTRIB_DESCRIPTION=.*$" /etc/*-release | # extract only distrib description
-cut -d= -f2 # get distrib description value only
+    cut -d= -f2 # get distrib description value only
 
 echo
 echo "## Android environment"
@@ -16,10 +16,6 @@ gcloud --version | while read -r lib; do
     name=$(echo $lib | awk '{$NF=""; print $0}')
     echo "| $name | $version |"
 done
-
-echo "## APT packages"
-dpkg -l
-echo
 
 echo "## Python environment"
 echo "### Python version"
@@ -37,9 +33,9 @@ done
 
 echo "## Ruby environment"
 echo "### Default ruby version"
-ruby -v | cut -d' ' -f2-
+ruby --version | cut -d' ' -f2-
 echo "### rbenv"
-rbenv -v | cut -d' ' -f2-
+rbenv --version | cut -d' ' -f2-
 echo "### Installed gems:"
 echo "| Name | Version |"
 echo "|------|---------|"
@@ -48,4 +44,8 @@ gem list | while read -r lib; do
     name=$(echo $lib | awk -F"[()]" '{print $1}')
     echo "| $name | $version |"
 done
+echo
+
+echo "## APT packages"
+dpkg --list
 echo

--- a/desc/desc.sh
+++ b/desc/desc.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 echo "## Image environment"
-cat /etc/*-release
+grep "DISTRIB_DESCRIPTION=.*$" /etc/*-release | # extract only distrib description
+cut -d= -f2 # get distrib description value only
+
 echo
 echo "## Android environment"
 echo "### Android SDKs"
@@ -16,9 +18,9 @@ echo
 
 echo "## Ruby environment"
 echo "### Default ruby version"
-ruby -v
+ruby -v | cut -d' ' -f2-
 echo "### rbenv"
-rbenv -v
+rbenv -v | cut -d' ' -f2-
 echo "### Installed gems:"
 gem list
 echo

--- a/desc/desc.sh
+++ b/desc/desc.sh
@@ -21,6 +21,20 @@ echo "## APT packages"
 dpkg -l
 echo
 
+echo "## Python environment"
+echo "### Python version"
+python3 --version | cut -d' ' -f2-
+echo "### PIP version"
+pip3 --version | cut -d' ' -f2-
+echo "### Installed PIP packages"
+echo "| Name | Version |"
+echo "|------|---------|"
+pip3 freeze | while read -r lib; do
+    version=$(echo "$lib" | awk -F'=='  '{print $2}')
+    name=$(echo "$lib" | awk -F'=='  '{print $1}')
+    echo "| $name | $version |"
+done
+
 echo "## Ruby environment"
 echo "### Default ruby version"
 ruby -v | cut -d' ' -f2-

--- a/desc/desc.sh
+++ b/desc/desc.sh
@@ -27,5 +27,11 @@ ruby -v | cut -d' ' -f2-
 echo "### rbenv"
 rbenv -v | cut -d' ' -f2-
 echo "### Installed gems:"
-gem list
+echo "| Name | Version |"
+echo "|------|---------|"
+gem list | while read -r lib; do
+    version=$(echo $lib | awk -F"[()]" '{print $2}')
+    name=$(echo $lib | awk -F"[()]" '{print $1}')
+    echo "| $name | $version |"
+done
 echo

--- a/desc/desc.sh
+++ b/desc/desc.sh
@@ -47,5 +47,8 @@ done
 echo
 
 echo "## APT packages"
-dpkg --list
-echo
+echo "| Name | Version | Architecture | Description |"
+echo "| ---- | ------- | ------------ | ----------- |"
+dpkg_format='| ${binary:Package} | ${Version} | ${Architecture} | ${binary:Summary} |\n'
+dpkg-query --show --showformat="$dpkg_format"
+done


### PR DESCRIPTION
desc script now format using markdown tables

Fixes #60 
Fixes #63 

<details>
  <summary>Sample</summary>

## Image environment
"Ubuntu 20.04 LTS"

## Android environment
### Android SDKs
  Path                 | Version | Description                    | Location             
  -------              | ------- | -------                        | -------              
  build-tools;29.0.3   | 29.0.3  | Android SDK Build-Tools 29.0.3 | build-tools/29.0.3/  
  platform-tools       | 30.0.1  | Android SDK Platform-Tools     | platform-tools/      
  platforms;android-29 | 4       | Android SDK Platform 29        | platforms/android-29/
  tools                | 1.0.0   | Android SDK Tools 1            | tools/               

### Google Cloud SDK
| Name | Version |
|------|---------|
| Google Cloud SDK  | 292.0.0 |
| bq  | 2.0.57 |
| core  | 2020.05.08 |
| gsutil  | 4.50 |
## Python environment
### Python version
3.8.2
### PIP version
20.0.2 from /usr/lib/python3/dist-packages/pip (python 3.8)
### Installed PIP packages
| Name | Version |
|------|---------|
| crcmod | 1.7 |
## Ruby environment
### Default ruby version
2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-linux]
### rbenv
1.1.2-30-gc879cb0
### Installed gems:
| Name | Version |
|------|---------|
| benchmark  | default: 0.1.0 |
| bigdecimal  | default: 2.0.0 |
| bundler  | 2.1.4, default: 2.1.2 |
| cgi  | default: 0.1.0 |
| csv  | default: 3.1.2 |
| date  | default: 3.0.0 |
| delegate  | default: 0.1.0 |
| did_you_mean  | default: 1.4.0 |
| etc  | default: 1.1.0 |
| fcntl  | default: 1.0.0 |
| fiddle  | default: 1.0.0 |
| fileutils  | default: 1.4.1 |
| forwardable  | default: 1.3.1 |
| getoptlong  | default: 0.1.0 |
| io-console  | default: 0.5.3 |
| ipaddr  | default: 1.2.2 |
| irb  | default: 1.2.1 |
| json  | default: 2.3.0 |
| logger  | default: 1.4.2 |
| matrix  | default: 0.2.0 |
| minitest  | 5.13.0 |
| mutex_m  | default: 0.1.0 |
| net-pop  | default: 0.1.0 |
| net-smtp  | default: 0.1.0 |
| net-telnet  | 0.2.0 |
| observer  | default: 0.1.0 |
| open3  | default: 0.1.0 |
| openssl  | default: 2.1.2 |
| ostruct  | default: 0.2.0 |
| power_assert  | 1.1.5 |
| prime  | default: 0.1.1 |
| pstore  | default: 0.1.0 |
| psych  | default: 3.1.0 |
| racc  | default: 1.4.16 |
| rake  | 13.0.1 |
| rdoc  | default: 6.2.1 |
| readline  | default: 0.0.2 |
| readline-ext  | default: 0.1.0 |
| reline  | default: 0.1.2 |
| rexml  | default: 3.2.3 |
| rss  | default: 0.2.8 |
| sdbm  | default: 1.0.0 |
| singleton  | default: 0.1.0 |
| stringio  | default: 0.1.0 |
| strscan  | default: 1.0.3 |
| test-unit  | 3.3.4 |
| timeout  | default: 0.1.0 |
| tracer  | default: 0.1.0 |
| uri  | default: 0.10.0 |
| webrick  | default: 1.6.0 |
| xmlrpc  | 0.3.0 |
| yaml  | default: 0.1.0 |
| zlib  | default: 1.1.0 |

## APT packages
| Name | Version | Architecture | Description |
| ---- | ------- | ------------ | ----------- |
| adduser | 3.118ubuntu2 | all | add and remove users and groups |
| apt | 2.0.2 | amd64 | commandline package manager |
| base-files | 11ubuntu5 | amd64 | Debian base system miscellaneous files |
| base-passwd | 3.5.47 | amd64 | Debian base system master password and group files |
| bash | 5.0-6ubuntu1 | amd64 | GNU Bourne Again SHell |
| binutils | 2.34-6ubuntu1 | amd64 | GNU assembler, linker and binary utilities |
| binutils-common:amd64 | 2.34-6ubuntu1 | amd64 | Common files for the GNU assembler, linker and binary utilities |
| binutils-x86-64-linux-gnu | 2.34-6ubuntu1 | amd64 | GNU binary utilities, for x86-64-linux-gnu target |
| bsdutils | 1:2.34-0.1ubuntu9 | amd64 | basic utilities from 4.4BSD-Lite |
| build-essential | 12.8ubuntu1 | amd64 | Informational list of build-essential packages |
| bzip2 | 1.0.8-2 | amd64 | high-quality block-sorting file compressor - utilities |
| ca-certificates | 20190110ubuntu1 | all | Common CA certificates |
| ca-certificates-java | 20190405ubuntu1 | all | Common CA certificates (JKS keystore) |
| coreutils | 8.30-3ubuntu2 | amd64 | GNU core utilities |
| cpp | 4:9.3.0-1ubuntu2 | amd64 | GNU C preprocessor (cpp) |
| cpp-9 | 9.3.0-10ubuntu2 | amd64 | GNU C preprocessor |
| dash | 0.5.10.2-6 | amd64 | POSIX-compliant shell |
| debconf | 1.5.73 | all | Debian configuration management system |
| debianutils | 4.9.1 | amd64 | Miscellaneous utilities specific to Debian |
| diffutils | 1:3.7-3 | amd64 | File comparison utilities |
| dpkg | 1.19.7ubuntu3 | amd64 | Debian package management system |
| dpkg-dev | 1.19.7ubuntu3 | all | Debian package development tools |
| e2fsprogs | 1.45.5-2ubuntu1 | amd64 | ext2/ext3/ext4 file system utilities |
| fdisk | 2.34-0.1ubuntu9 | amd64 | collection of partitioning utilities |
| findutils | 4.7.0-1ubuntu1 | amd64 | utilities for finding files--find, xargs |
| fontconfig-config | 2.13.1-2ubuntu3 | all | generic font configuration library - configuration |
| fonts-dejavu-core | 2.37-1 | all | Vera font family derivate with additional characters |
| g++ | 4:9.3.0-1ubuntu2 | amd64 | GNU C++ compiler |
| g++-9 | 9.3.0-10ubuntu2 | amd64 | GNU C++ compiler |
| gcc | 4:9.3.0-1ubuntu2 | amd64 | GNU C compiler |
| gcc-10-base:amd64 | 10-20200411-0ubuntu1 | amd64 | GCC, the GNU Compiler Collection (base package) |
| gcc-9 | 9.3.0-10ubuntu2 | amd64 | GNU C compiler |
| gcc-9-base:amd64 | 9.3.0-10ubuntu2 | amd64 | GCC, the GNU Compiler Collection (base package) |
| git | 1:2.25.1-1ubuntu3 | amd64 | fast, scalable, distributed revision control system |
| git-man | 1:2.25.1-1ubuntu3 | all | fast, scalable, distributed revision control system (manual pages) |
| gpgv | 2.2.19-3ubuntu2 | amd64 | GNU privacy guard - signature verification tool |
| grep | 3.4-1 | amd64 | GNU grep, egrep and fgrep |
| gzip | 1.10-0ubuntu4 | amd64 | GNU compression utilities |
| hostname | 3.23 | amd64 | utility to set/show the host name or domain name |
| init-system-helpers | 1.57 | all | helper tools for all init systems |
| java-common | 0.72 | all | Base package for Java runtimes |
| libacl1:amd64 | 2.2.53-6 | amd64 | access control list - shared library |
| libapt-pkg6.0:amd64 | 2.0.2 | amd64 | package management runtime library |
| libasan5:amd64 | 9.3.0-10ubuntu2 | amd64 | AddressSanitizer -- a fast memory error detector |
| libasn1-8-heimdal:amd64 | 7.7.0+dfsg-1ubuntu1 | amd64 | Heimdal Kerberos - ASN.1 library |
| libasound2:amd64 | 1.2.2-2.1 | amd64 | shared library for ALSA applications |
| libasound2-data | 1.2.2-2.1 | all | Configuration files and profiles for ALSA drivers |
| libatomic1:amd64 | 10-20200411-0ubuntu1 | amd64 | support library providing __atomic built-in functions |
| libattr1:amd64 | 1:2.4.48-5 | amd64 | extended attribute handling - shared library |
| libaudit-common | 1:2.8.5-2ubuntu6 | all | Dynamic library for security auditing - common files |
| libaudit1:amd64 | 1:2.8.5-2ubuntu6 | amd64 | Dynamic library for security auditing |
| libavahi-client3:amd64 | 0.7-4ubuntu7 | amd64 | Avahi client library |
| libavahi-common-data:amd64 | 0.7-4ubuntu7 | amd64 | Avahi common data files |
| libavahi-common3:amd64 | 0.7-4ubuntu7 | amd64 | Avahi common library |
| libbinutils:amd64 | 2.34-6ubuntu1 | amd64 | GNU binary utilities (private shared library) |
| libblkid1:amd64 | 2.34-0.1ubuntu9 | amd64 | block device ID library |
| libbrotli1:amd64 | 1.0.7-6build1 | amd64 | library implementing brotli encoder and decoder (shared libraries) |
| libbsd0:amd64 | 0.10.0-1 | amd64 | utility functions from BSD systems - shared library |
| libbz2-1.0:amd64 | 1.0.8-2 | amd64 | high-quality block-sorting file compressor library - runtime |
| libc-bin | 2.31-0ubuntu9 | amd64 | GNU C Library: Binaries |
| libc-dev-bin | 2.31-0ubuntu9 | amd64 | GNU C Library: Development binaries |
| libc6:amd64 | 2.31-0ubuntu9 | amd64 | GNU C Library: Shared libraries |
| libc6-dev:amd64 | 2.31-0ubuntu9 | amd64 | GNU C Library: Development Libraries and Header Files |
| libcap-ng0:amd64 | 0.7.9-2.1build1 | amd64 | An alternate POSIX capabilities library |
| libcc1-0:amd64 | 10-20200411-0ubuntu1 | amd64 | GCC cc1 plugin for GDB |
| libcom-err2:amd64 | 1.45.5-2ubuntu1 | amd64 | common error description library |
| libcrypt-dev:amd64 | 1:4.4.10-10ubuntu4 | amd64 | libcrypt development files |
| libcrypt1:amd64 | 1:4.4.10-10ubuntu4 | amd64 | libcrypt shared library |
| libctf-nobfd0:amd64 | 2.34-6ubuntu1 | amd64 | Compact C Type Format library (runtime, no BFD dependency) |
| libctf0:amd64 | 2.34-6ubuntu1 | amd64 | Compact C Type Format library (runtime, BFD dependency) |
| libcups2:amd64 | 2.3.1-9ubuntu1.1 | amd64 | Common UNIX Printing System(tm) - Core library |
| libcurl3-gnutls:amd64 | 7.68.0-1ubuntu2 | amd64 | easy-to-use client-side URL transfer library (GnuTLS flavour) |
| libdb5.3:amd64 | 5.3.28+dfsg1-0.6ubuntu2 | amd64 | Berkeley v5.3 Database Libraries [runtime] |
| libdbus-1-3:amd64 | 1.12.16-2ubuntu2 | amd64 | simple interprocess messaging system (library) |
| libdebconfclient0:amd64 | 0.251ubuntu1 | amd64 | Debian Configuration Management System (C-implementation library) |
| libdpkg-perl | 1.19.7ubuntu3 | all | Dpkg perl modules |
| libdrm-amdgpu1:amd64 | 2.4.101-2 | amd64 | Userspace interface to amdgpu-specific kernel DRM services -- runtime |
| libdrm-common | 2.4.101-2 | all | Userspace interface to kernel DRM services -- common files |
| libdrm-intel1:amd64 | 2.4.101-2 | amd64 | Userspace interface to intel-specific kernel DRM services -- runtime |
| libdrm-nouveau2:amd64 | 2.4.101-2 | amd64 | Userspace interface to nouveau-specific kernel DRM services -- runtime |
| libdrm-radeon1:amd64 | 2.4.101-2 | amd64 | Userspace interface to radeon-specific kernel DRM services -- runtime |
| libdrm2:amd64 | 2.4.101-2 | amd64 | Userspace interface to kernel DRM services -- runtime |
| libedit2:amd64 | 3.1-20191231-1 | amd64 | BSD editline and history libraries |
| libelf1:amd64 | 0.176-1.1build1 | amd64 | library to read and write ELF files |
| liberror-perl | 0.17029-1 | all | Perl module for error/exception handling in an OO-ish way |
| libexpat1:amd64 | 2.2.9-1build1 | amd64 | XML parsing C library - runtime library |
| libexpat1-dev:amd64 | 2.2.9-1build1 | amd64 | XML parsing C library - development kit |
| libext2fs2:amd64 | 1.45.5-2ubuntu1 | amd64 | ext2/ext3/ext4 file system libraries |
| libfdisk1:amd64 | 2.34-0.1ubuntu9 | amd64 | fdisk partitioning library |
| libffi7:amd64 | 3.3-4 | amd64 | Foreign Function Interface library runtime |
| libfontconfig1:amd64 | 2.13.1-2ubuntu3 | amd64 | generic font configuration library - runtime |
| libfreetype6:amd64 | 2.10.1-2 | amd64 | FreeType 2 font engine, shared library files |
| libgcc-9-dev:amd64 | 9.3.0-10ubuntu2 | amd64 | GCC support library (development files) |
| libgcc-s1:amd64 | 10-20200411-0ubuntu1 | amd64 | GCC support library |
| libgcrypt20:amd64 | 1.8.5-5ubuntu1 | amd64 | LGPL Crypto library - runtime library |
| libgdbm-compat4:amd64 | 1.18.1-5 | amd64 | GNU dbm database routines (legacy support runtime version)  |
| libgdbm6:amd64 | 1.18.1-5 | amd64 | GNU dbm database routines (runtime version)  |
| libgif7:amd64 | 5.1.9-1 | amd64 | library for GIF images (library) |
| libgl1:amd64 | 1.3.1-1 | amd64 | Vendor neutral GL dispatch library -- legacy GL support |
| libgl1-mesa-dri:amd64 | 20.0.4-2ubuntu1 | amd64 | free implementation of the OpenGL API -- DRI modules |
| libglapi-mesa:amd64 | 20.0.4-2ubuntu1 | amd64 | free implementation of the GL API -- shared library |
| libglvnd0:amd64 | 1.3.1-1 | amd64 | Vendor neutral GL dispatch library |
| libglx-mesa0:amd64 | 20.0.4-2ubuntu1 | amd64 | free implementation of the OpenGL API -- GLX vendor library |
| libglx0:amd64 | 1.3.1-1 | amd64 | Vendor neutral GL dispatch library -- GLX support |
| libgmp10:amd64 | 2:6.2.0+dfsg-4 | amd64 | Multiprecision arithmetic library |
| libgnutls30:amd64 | 3.6.13-2ubuntu1 | amd64 | GNU TLS library - main runtime library |
| libgomp1:amd64 | 10-20200411-0ubuntu1 | amd64 | GCC OpenMP (GOMP) support library |
| libgpg-error0:amd64 | 1.37-1 | amd64 | GnuPG development runtime library |
| libgssapi-krb5-2:amd64 | 1.17-6ubuntu4 | amd64 | MIT Kerberos runtime libraries - krb5 GSS-API Mechanism |
| libgssapi3-heimdal:amd64 | 7.7.0+dfsg-1ubuntu1 | amd64 | Heimdal Kerberos - GSSAPI support library |
| libhcrypto4-heimdal:amd64 | 7.7.0+dfsg-1ubuntu1 | amd64 | Heimdal Kerberos - crypto library |
| libheimbase1-heimdal:amd64 | 7.7.0+dfsg-1ubuntu1 | amd64 | Heimdal Kerberos - Base library |
| libheimntlm0-heimdal:amd64 | 7.7.0+dfsg-1ubuntu1 | amd64 | Heimdal Kerberos - NTLM support library |
| libhogweed5:amd64 | 3.5.1+really3.5.1-2 | amd64 | low level cryptographic library (public-key cryptos) |
| libhx509-5-heimdal:amd64 | 7.7.0+dfsg-1ubuntu1 | amd64 | Heimdal Kerberos - X509 support library |
| libidn2-0:amd64 | 2.2.0-2 | amd64 | Internationalized domain names (IDNA2008/TR46) library |
| libisl22:amd64 | 0.22.1-1 | amd64 | manipulating sets and relations of integer points bounded by linear constraints |
| libitm1:amd64 | 10-20200411-0ubuntu1 | amd64 | GNU Transactional Memory Library |
| libjpeg-turbo8:amd64 | 2.0.3-0ubuntu1 | amd64 | IJG JPEG compliant runtime library. |
| libjpeg8:amd64 | 8c-2ubuntu8 | amd64 | Independent JPEG Group's JPEG runtime library (dependency package) |
| libk5crypto3:amd64 | 1.17-6ubuntu4 | amd64 | MIT Kerberos runtime libraries - Crypto Library |
| libkeyutils1:amd64 | 1.6-6ubuntu1 | amd64 | Linux Key Management Utilities (library) |
| libkrb5-26-heimdal:amd64 | 7.7.0+dfsg-1ubuntu1 | amd64 | Heimdal Kerberos - libraries |
| libkrb5-3:amd64 | 1.17-6ubuntu4 | amd64 | MIT Kerberos runtime libraries |
| libkrb5support0:amd64 | 1.17-6ubuntu4 | amd64 | MIT Kerberos runtime libraries - Support library |
| liblcms2-2:amd64 | 2.9-4 | amd64 | Little CMS 2 color management library |
| libldap-2.4-2:amd64 | 2.4.49+dfsg-2ubuntu1.2 | amd64 | OpenLDAP libraries |
| libldap-common | 2.4.49+dfsg-2ubuntu1.2 | all | OpenLDAP common files for libraries |
| libllvm9:amd64 | 1:9.0.1-12 | amd64 | Modular compiler and toolchain technologies, runtime library |
| liblsan0:amd64 | 10-20200411-0ubuntu1 | amd64 | LeakSanitizer -- a memory leak detector (runtime) |
| liblz4-1:amd64 | 1.9.2-2 | amd64 | Fast LZ compression algorithm library - runtime |
| liblzma5:amd64 | 5.2.4-1 | amd64 | XZ-format compression library |
| libmount1:amd64 | 2.34-0.1ubuntu9 | amd64 | device mounting library |
| libmpc3:amd64 | 1.1.0-1 | amd64 | multiple precision complex floating-point library |
| libmpdec2:amd64 | 2.4.2-3 | amd64 | library for decimal floating point arithmetic (runtime library) |
| libmpfr6:amd64 | 4.0.2-1 | amd64 | multiple precision floating-point computation |
| libncurses-dev:amd64 | 6.2-0ubuntu2 | amd64 | developer's libraries for ncurses |
| libncurses6:amd64 | 6.2-0ubuntu2 | amd64 | shared libraries for terminal handling |
| libncursesw6:amd64 | 6.2-0ubuntu2 | amd64 | shared libraries for terminal handling (wide character support) |
| libnettle7:amd64 | 3.5.1+really3.5.1-2 | amd64 | low level cryptographic library (symmetric and one-way cryptos) |
| libnghttp2-14:amd64 | 1.40.0-1build1 | amd64 | library implementing HTTP/2 protocol (shared library) |
| libnspr4:amd64 | 2:4.25-1 | amd64 | NetScape Portable Runtime Library |
| libnss3:amd64 | 2:3.49.1-1ubuntu1 | amd64 | Network Security Service libraries |
| libp11-kit0:amd64 | 0.23.20-1build1 | amd64 | library for loading and coordinating access to PKCS#11 modules - runtime |
| libpam-modules:amd64 | 1.3.1-5ubuntu4 | amd64 | Pluggable Authentication Modules for PAM |
| libpam-modules-bin | 1.3.1-5ubuntu4 | amd64 | Pluggable Authentication Modules for PAM - helper binaries |
| libpam-runtime | 1.3.1-5ubuntu4 | all | Runtime support for the PAM library |
| libpam0g:amd64 | 1.3.1-5ubuntu4 | amd64 | Pluggable Authentication Modules library |
| libpciaccess0:amd64 | 0.16-0ubuntu1 | amd64 | Generic PCI access library for X |
| libpcre2-8-0:amd64 | 10.34-7 | amd64 | New Perl Compatible Regular Expression Library- 8 bit runtime files |
| libpcre3:amd64 | 2:8.39-12build1 | amd64 | Old Perl 5 Compatible Regular Expression Library - runtime files |
| libpcsclite1:amd64 | 1.8.26-3 | amd64 | Middleware to access a smart card using PC/SC (library) |
| libperl5.30:amd64 | 5.30.0-9build1 | amd64 | shared Perl library |
| libpng16-16:amd64 | 1.6.37-2 | amd64 | PNG library - runtime (version 1.6) |
| libprocps8:amd64 | 2:3.3.16-1ubuntu2 | amd64 | library for accessing process information from /proc |
| libpsl5:amd64 | 0.21.0-1ubuntu1 | amd64 | Library for Public Suffix List (shared libraries) |
| libpython3-dev:amd64 | 3.8.2-0ubuntu2 | amd64 | header files and a static library for Python (default) |
| libpython3-stdlib:amd64 | 3.8.2-0ubuntu2 | amd64 | interactive high-level object-oriented language (default python3 version) |
| libpython3.8:amd64 | 3.8.2-1ubuntu1.1 | amd64 | Shared Python runtime library (version 3.8) |
| libpython3.8-dev:amd64 | 3.8.2-1ubuntu1.1 | amd64 | Header files and a static library for Python (v3.8) |
| libpython3.8-minimal:amd64 | 3.8.2-1ubuntu1.1 | amd64 | Minimal subset of the Python language (version 3.8) |
| libpython3.8-stdlib:amd64 | 3.8.2-1ubuntu1.1 | amd64 | Interactive high-level object-oriented language (standard library, version 3.8) |
| libquadmath0:amd64 | 10-20200411-0ubuntu1 | amd64 | GCC Quad-Precision Math Library |
| libreadline-dev:amd64 | 8.0-4 | amd64 | GNU readline and history libraries, development files |
| libreadline8:amd64 | 8.0-4 | amd64 | GNU readline and history libraries, run-time libraries |
| libroken18-heimdal:amd64 | 7.7.0+dfsg-1ubuntu1 | amd64 | Heimdal Kerberos - roken support library |
| librtmp1:amd64 | 2.4+20151223.gitfa8646d.1-2build1 | amd64 | toolkit for RTMP streams (shared library) |
| libsasl2-2:amd64 | 2.1.27+dfsg-2 | amd64 | Cyrus SASL - authentication abstraction library |
| libsasl2-modules-db:amd64 | 2.1.27+dfsg-2 | amd64 | Cyrus SASL - pluggable authentication modules (DB) |
| libseccomp2:amd64 | 2.4.3-1ubuntu1 | amd64 | high level interface to Linux seccomp filter |
| libselinux1:amd64 | 3.0-1build2 | amd64 | SELinux runtime shared libraries |
| libsemanage-common | 3.0-1build2 | all | Common files for SELinux policy management libraries |
| libsemanage1:amd64 | 3.0-1build2 | amd64 | SELinux policy management library |
| libsensors-config | 1:3.6.0-2ubuntu1 | all | lm-sensors configuration files |
| libsensors5:amd64 | 1:3.6.0-2ubuntu1 | amd64 | library to read temperature/voltage/fan sensors |
| libsepol1:amd64 | 3.0-1 | amd64 | SELinux library for manipulating binary security policies |
| libsmartcols1:amd64 | 2.34-0.1ubuntu9 | amd64 | smart column output alignment library |
| libsqlite3-0:amd64 | 3.31.1-4 | amd64 | SQLite 3 shared library |
| libss2:amd64 | 1.45.5-2ubuntu1 | amd64 | command-line interface parsing library |
| libssh-4:amd64 | 0.9.3-2ubuntu2 | amd64 | tiny C SSH library (OpenSSL flavor) |
| libssl-dev:amd64 | 1.1.1f-1ubuntu2 | amd64 | Secure Sockets Layer toolkit - development files |
| libssl1.1:amd64 | 1.1.1f-1ubuntu2 | amd64 | Secure Sockets Layer toolkit - shared libraries |
| libstdc++-9-dev:amd64 | 9.3.0-10ubuntu2 | amd64 | GNU Standard C++ Library v3 (development files) |
| libstdc++6:amd64 | 10-20200411-0ubuntu1 | amd64 | GNU Standard C++ Library v3 |
| libsystemd0:amd64 | 245.4-4ubuntu3 | amd64 | systemd utility library |
| libtasn1-6:amd64 | 4.16.0-2 | amd64 | Manage ASN.1 structures (runtime) |
| libtinfo6:amd64 | 6.2-0ubuntu2 | amd64 | shared low-level terminfo library for terminal handling |
| libtsan0:amd64 | 10-20200411-0ubuntu1 | amd64 | ThreadSanitizer -- a Valgrind-based detector of data races (runtime) |
| libubsan1:amd64 | 10-20200411-0ubuntu1 | amd64 | UBSan -- undefined behaviour sanitizer (runtime) |
| libudev1:amd64 | 245.4-4ubuntu3 | amd64 | libudev shared library |
| libunistring2:amd64 | 0.9.10-2 | amd64 | Unicode string library for C |
| libuuid1:amd64 | 2.34-0.1ubuntu9 | amd64 | Universally Unique ID library |
| libvulkan1:amd64 | 1.2.131.2-1 | amd64 | Vulkan loader library |
| libwind0-heimdal:amd64 | 7.7.0+dfsg-1ubuntu1 | amd64 | Heimdal Kerberos - stringprep implementation |
| libx11-6:amd64 | 2:1.6.9-2ubuntu1 | amd64 | X11 client-side library |
| libx11-data | 2:1.6.9-2ubuntu1 | all | X11 client-side library |
| libx11-xcb1:amd64 | 2:1.6.9-2ubuntu1 | amd64 | Xlib/XCB interface library |
| libxau6:amd64 | 1:1.0.9-0ubuntu1 | amd64 | X11 authorisation library |
| libxcb-dri2-0:amd64 | 1.14-2 | amd64 | X C Binding, dri2 extension |
| libxcb-dri3-0:amd64 | 1.14-2 | amd64 | X C Binding, dri3 extension |
| libxcb-glx0:amd64 | 1.14-2 | amd64 | X C Binding, glx extension |
| libxcb-present0:amd64 | 1.14-2 | amd64 | X C Binding, present extension |
| libxcb-sync1:amd64 | 1.14-2 | amd64 | X C Binding, sync extension |
| libxcb1:amd64 | 1.14-2 | amd64 | X C Binding |
| libxdamage1:amd64 | 1:1.1.5-2 | amd64 | X11 damaged region extension library |
| libxdmcp6:amd64 | 1:1.1.3-0ubuntu1 | amd64 | X11 Display Manager Control Protocol library |
| libxext6:amd64 | 2:1.3.4-0ubuntu1 | amd64 | X11 miscellaneous extension library |
| libxfixes3:amd64 | 1:5.0.3-2 | amd64 | X11 miscellaneous 'fixes' extension library |
| libxi6:amd64 | 2:1.7.10-0ubuntu1 | amd64 | X11 Input extension library |
| libxrender1:amd64 | 1:0.9.10-1 | amd64 | X Rendering Extension client library |
| libxshmfence1:amd64 | 1.3-1 | amd64 | X shared memory fences - shared library |
| libxtst6:amd64 | 2:1.2.3-1 | amd64 | X11 Testing -- Record extension library |
| libxxf86vm1:amd64 | 1:1.1.4-1build1 | amd64 | X11 XFree86 video mode extension library |
| libzstd1:amd64 | 1.4.4+dfsg-3 | amd64 | fast lossless compression algorithm |
| linux-libc-dev:amd64 | 5.4.0-29.33 | amd64 | Linux Kernel Headers for development |
| locales | 2.31-0ubuntu9 | all | GNU C Library: National Language (locale) data [support] |
| login | 1:4.8.1-1ubuntu5 | amd64 | system login tools |
| logsave | 1.45.5-2ubuntu1 | amd64 | save the output of a command in a log file |
| lsb-base | 11.1.0ubuntu2 | all | Linux Standard Base init script functionality |
| make | 4.2.1-1.2 | amd64 | utility for directing compilation |
| mawk | 1.3.4.20200120-2 | amd64 | Pattern scanning and text processing language |
| mime-support | 3.64ubuntu1 | all | MIME files 'mime.types' & 'mailcap', and support programs |
| mount | 2.34-0.1ubuntu9 | amd64 | tools for mounting and manipulating filesystems |
| ncurses-base | 6.2-0ubuntu2 | all | basic terminal type definitions |
| ncurses-bin | 6.2-0ubuntu2 | amd64 | terminal-related programs and man pages |
| openjdk-11-jdk:amd64 | 11.0.7+10-3ubuntu1 | amd64 | OpenJDK Development Kit (JDK) |
| openjdk-11-jdk-headless:amd64 | 11.0.7+10-3ubuntu1 | amd64 | OpenJDK Development Kit (JDK) (headless) |
| openjdk-11-jre:amd64 | 11.0.7+10-3ubuntu1 | amd64 | OpenJDK Java runtime, using Hotspot JIT |
| openjdk-11-jre-headless:amd64 | 11.0.7+10-3ubuntu1 | amd64 | OpenJDK Java runtime, using Hotspot JIT (headless) |
| openssl | 1.1.1f-1ubuntu2 | amd64 | Secure Sockets Layer toolkit - cryptographic utility |
| passwd | 1:4.8.1-1ubuntu5 | amd64 | change and administer password and group data |
| patch | 2.7.6-6 | amd64 | Apply a diff file to an original |
| perl | 5.30.0-9build1 | amd64 | Larry Wall's Practical Extraction and Report Language |
| perl-base | 5.30.0-9build1 | amd64 | minimal Perl system |
| perl-modules-5.30 | 5.30.0-9build1 | all | Core Perl modules |
| procps | 2:3.3.16-1ubuntu2 | amd64 | /proc file system utilities |
| python-pip-whl | 20.0.2-5ubuntu1 | all | Python package installer |
| python3 | 3.8.2-0ubuntu2 | amd64 | interactive high-level object-oriented language (default python3 version) |
| python3-dev | 3.8.2-0ubuntu2 | amd64 | header files and a static library for Python (default) |
| python3-distutils | 3.8.2-1ubuntu1 | all | distutils package for Python 3.x |
| python3-lib2to3 | 3.8.2-1ubuntu1 | all | Interactive high-level object-oriented language (lib2to3) |
| python3-minimal | 3.8.2-0ubuntu2 | amd64 | minimal subset of the Python language (default python3 version) |
| python3-pip | 20.0.2-5ubuntu1 | all | Python package installer |
| python3-pkg-resources | 45.2.0-1 | all | Package Discovery and Resource Access using pkg_resources |
| python3-setuptools | 45.2.0-1 | all | Python3 Distutils Enhancements |
| python3-wheel | 0.34.2-1 | all | built-package format for Python |
| python3.8 | 3.8.2-1ubuntu1.1 | amd64 | Interactive high-level object-oriented language (version 3.8) |
| python3.8-dev | 3.8.2-1ubuntu1.1 | amd64 | Header files and a static library for Python (v3.8) |
| python3.8-minimal | 3.8.2-1ubuntu1.1 | amd64 | Minimal subset of the Python language (version 3.8) |
| readline-common | 8.0-4 | all | GNU readline and history libraries, common files |
| sed | 4.7-1 | amd64 | GNU stream editor for filtering/transforming text |
| sensible-utils | 0.0.12+nmu1 | all | Utilities for sensible alternative selection |
| sysvinit-utils | 2.96-2.1ubuntu1 | amd64 | System-V-like utilities |
| tar | 1.30+dfsg-7 | amd64 | GNU version of the tar archiving utility |
| ubuntu-keyring | 2020.02.11.2 | all | GnuPG keys of the Ubuntu archive |
| ucf | 3.0038+nmu1 | all | Update Configuration File(s): preserve user changes to config files |
| unzip | 6.0-25ubuntu1 | amd64 | De-archiver for .zip files |
| util-linux | 2.34-0.1ubuntu9 | amd64 | miscellaneous system utilities |
| wget | 1.20.3-1ubuntu1 | amd64 | retrieves files from the web |
| x11-common | 1:7.7+19ubuntu14 | all | X Window System (X.Org) infrastructure |
| xz-utils | 5.2.4-1 | amd64 | XZ-format compression utilities |
| zlib1g:amd64 | 1:1.2.11.dfsg-2ubuntu1 | amd64 | compression library - runtime |
| zlib1g-dev:amd64 | 1:1.2.11.dfsg-2ubuntu1 | amd64 | compression library - development |
</details>
