### PR TITLE
Make Gcloud installation optional

### DIFF
--- a/.github/workflows/cd_prepare_release.yml
+++ b/.github/workflows/cd_prepare_release.yml
@@ -29,6 +29,7 @@ jobs:
       matrix:
         android_api: [28, 29]
         android_ndk: ["--android-ndk", ""]
+        gcloud: ["--gcloud", ""]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -36,7 +37,7 @@ jobs:
       - name: Build test deploy describe image
         env:
           RELEASE_NAME: ${{ needs.job_compute_release_name.outputs.release_name }}
-        run: ./ci_cd.sh --build --test --desc --android-api ${{ matrix.android_api }} ${{ matrix.android_ndk }}
+        run: ./ci_cd.sh --build --test --desc --android-api ${{ matrix.android_api }} ${{ matrix.android_ndk }} ${{ matrix.gcloud }}
 
       - name: Upload image description
         uses: actions/upload-artifact@v2-preview

--- a/.github/workflows/cd_publish_release.yml
+++ b/.github/workflows/cd_publish_release.yml
@@ -28,6 +28,7 @@ jobs:
       matrix:
         android_api: [28, 29]
         android_ndk: ["--android-ndk",""]
+        gcloud: ["--gcloud", ""]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -36,4 +37,4 @@ jobs:
         env:
           RELEASE_NAME: ${{ needs.job_compute_release_name.outputs.release_name }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: ./ci_cd.sh --build --test --deploy --android-api ${{ matrix.android_api }} ${{ matrix.android_ndk }}
+        run: ./ci_cd.sh --build --test --deploy --android-api ${{ matrix.android_api }} ${{ matrix.android_ndk }} ${{ matrix.gcloud }}

--- a/.github/workflows/cd_snapshot.yml
+++ b/.github/workflows/cd_snapshot.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         android_api: [28, 29]
         android_ndk: ["--android_ndk",""]
+        gcloud: ["--gcloud", ""]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -21,4 +22,4 @@ jobs:
         env:
           GIT_REF: ${{ github.ref }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: ./ci_cd.sh --build --test --deploy --android-api ${{ matrix.android_api }} ${{ matrix.android_ndk }}
+        run: ./ci_cd.sh --build --test --deploy --android-api ${{ matrix.android_api }} ${{ matrix.android_ndk }} ${{ matrix.gcloud }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,10 @@ jobs:
       matrix:
         android_api: [28, 29]
         android_ndk: ["--android_ndk",""]
+        gcloud: ["--gcloud", ""]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Build and test
-        run: ./ci_cd.sh --build --test --android-api ${{ matrix.android_api }} ${{ matrix.android_ndk }}
+        run: ./ci_cd.sh --build --test --android-api ${{ matrix.android_api }} ${{ matrix.android_ndk }} {{ matrix.gcloud }}

--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -36,3 +36,5 @@ jobs:
             sh tests/run_tests.sh --android-api 29 --android-ndk --android-build-tools 29.0.3;
             echo "Running Android 29 Tests";
             sh tests/run_tests.sh --android-api 29 --android-build-tools 29.0.3;
+            echo "Running Android 29 with GCloud Tests";
+            sh tests/run_tests.sh --android-api 29 --android-build-tools 29.0.3 --gcloud;

--- a/.github/workflows/daily_runner.yml
+++ b/.github/workflows/daily_runner.yml
@@ -10,8 +10,8 @@ jobs:
       options: --name=runner
     strategy:
       matrix:
-        android_api: [29]
-        android_ndk: [""]
+        android_api: [28,29]
+        android_ndk: ["--android-ndk"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -22,4 +22,4 @@ jobs:
         env:
           GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
-        run: ./ci_cd.sh --build --test --large-test --android-api ${{ matrix.android_api }} ${{ matrix.android_ndk }}
+        run: ./ci_cd.sh --build --test --large-test --android-api ${{ matrix.android_api }} ${{ matrix.android_ndk }} "--gcloud"

--- a/README.md
+++ b/README.md
@@ -102,9 +102,10 @@ docker-android images are hosted on [DockerHub](https://hub.docker.com/repositor
 ## 🔤 Naming
 We provide stable and snapshot variants for latest Android API levels, including or not native SDK.
 We use the following tagging policy:
-`API-NDK-VERSION`
+`API-NDK-GCLOUD-VERSION`
 * `API` the Android API to use, like `api-28`, `api-29`
 * `NDK` is the presence or not of the [Android NDK](https://developer.android.com/ndk) in the image
+* `GCLOUD` is the presence or not of the [Google Cloud SDK](https://cloud.google.com/sdk) in the image. (the gcloud sdk is needed for Firebase Test Lab for example).
 * `VERSION` is the image version. Check [Versions](https://github.com/faberNovel/docker-android/tree/master#versions)
 
 ## 🔢 Versions
@@ -124,6 +125,7 @@ All scripts must be POSIX compliants.
 usage: ./ci_cd.sh [--android-api 29] [--build] [--test]
   --android-api <androidVersion> Use specific Android version from `sdkmanager --list`
   --android-ndk                  Install Android NDK
+  --gcloud                       Install Google Cloud SDK
   --ndk-version <version>        Install a specific Android NDK version from `sdkmanager --list`
   --build                        Build image
   --test                         Test image

--- a/ci_cd.sh
+++ b/ci_cd.sh
@@ -114,6 +114,9 @@ if [ "$test" = true ]; then
     if [ "$android_ndk" = true ]; then
         test_options="$test_options --android-ndk"
     fi
+    if [[ "$gcloud" = true ]]; then
+      test_options="$test_options --gcloud"
+    fi
     if [ "$large_test" = true ]; then
         echo "Large test: $FIREBASE_PROJECT_ID"
         tasks=$((tasks+1))

--- a/ci_cd.sh
+++ b/ci_cd.sh
@@ -13,6 +13,7 @@ usage () {
   echo "  --android-api <androidVersion> Use specific Android version from \`sdkmanager --list\`"
   echo "  --android-ndk                  Install Android NDK"
   echo "  --ndk-version <version>        Install a specific Android NDK version from \`sdkmanager --list\`"
+  echo "  --gcloud                       Install the latest GCloud SDK version"
   echo "  --build                        Build image"
   echo "  --test                         Test image"
   echo "  --large-test                   Run large tests on the image (Firebase Test Lab for example)"
@@ -23,6 +24,7 @@ usage () {
 
 # Parameters parsing
 android_ndk=false
+gcloud=false
 large_test=false
 
 while true; do
@@ -32,6 +34,7 @@ while true; do
     --test ) test=true; shift ;;
     --android-ndk ) android_ndk=true; shift ;;
     --large-test ) large_test=true; shift ;;
+    --gcloud ) gcloud=true; shift ;;
     --ndk-version ) ndk_version="$2"; shift 2 ;;
     --deploy ) deploy=true; shift ;;
     --desc ) desc=true; shift ;;
@@ -59,12 +62,15 @@ if [ $large_test = true ]; then
 fi
 
 # Compute image tag
-org_name=fabernovel
-simple_image_name=api-$android_api
+org_name="fabernovel"
+simple_image_name="api-$android_api"
+if [[ "$gcloud" = true ]]; then
+  simple_image_name="$simple_image_name-gcloud"
+fi
 if [ "$android_ndk" = true ]; then
   simple_image_name="$simple_image_name-ndk"
 fi
-branch=${GIT_REF##refs/heads/}
+branch="${GIT_REF##refs/heads/}"
 if [ "$branch" = "develop" ]; then
   simple_image_name="$simple_image_name-snapshot"
 fi
@@ -86,6 +92,7 @@ if [ "$build" = true ]; then
   docker build \
     --build-arg android_api=android-$android_api \
     --build-arg android_ndk="$android_ndk" \
+    --build-arg gcloud="$gcloud" \
     $ndk_version_build_arg \
     --tag $full_image_name .
   set +x

--- a/desc/desc.sh
+++ b/desc/desc.sh
@@ -8,28 +8,31 @@ echo "## Android environment"
 echo "### Android SDKs"
 sdkmanager --list --sdk_root=$ANDROID_HOME |
     awk '/Installed packages:/{flag=1; next} /Available Packages/{flag=0} flag'
-echo "### Google Cloud SDK"
-echo "| Name | Version |"
-echo "|------|---------|"
-gcloud --version | while read -r lib; do
-    version=$(echo "${lib}" | awk '{ print $NF }')
-    name=$(echo $lib | awk '{$NF=""; print $0}')
-    echo "| $name | $version |"
-done
 
-echo "## Python environment"
-echo "### Python version"
-python3 --version | cut -d' ' -f2-
-echo "### PIP version"
-pip3 --version | cut -d' ' -f2-
-echo "### Installed PIP packages"
-echo "| Name | Version |"
-echo "|------|---------|"
-pip3 freeze | while read -r lib; do
-    version=$(echo "$lib" | awk -F'=='  '{print $2}')
-    name=$(echo "$lib" | awk -F'=='  '{print $1}')
-    echo "| $name | $version |"
-done
+if [ -n "$(which gcloud)" ]; then
+  echo "### Google Cloud SDK"
+  echo "| Name | Version |"
+  echo "|------|---------|"
+  gcloud --version | while read -r lib; do
+      version=$(echo "${lib}" | awk '{ print $NF }')
+      name=$(echo $lib | awk '{$NF=""; print $0}')
+      echo "| $name | $version |"
+  done
+
+  echo "## Python environment"
+  echo "### Python version"
+  python3 --version | cut -d' ' -f2-
+  echo "### PIP version"
+  pip3 --version | cut -d' ' -f2-
+  echo "### Installed PIP packages"
+  echo "| Name | Version |"
+  echo "|------|---------|"
+  pip3 freeze | while read -r lib; do
+      version=$(echo "$lib" | awk -F'=='  '{print $2}')
+      name=$(echo "$lib" | awk -F'=='  '{print $1}')
+      echo "| $name | $version |"
+  done
+fi
 
 echo "## Ruby environment"
 echo "### Default ruby version"
@@ -51,4 +54,3 @@ echo "| Name | Version | Architecture | Description |"
 echo "| ---- | ------- | ------------ | ----------- |"
 dpkg_format='| ${binary:Package} | ${Version} | ${Architecture} | ${binary:Summary} |\n'
 dpkg-query --show --showformat="$dpkg_format"
-done

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -11,6 +11,7 @@ usage() {
     echo "usage: $script_name [--android-ndk] --android-api <api> --android-build-tools <build tools version>"
     echo " --android-ndk Test with NDK application"
     echo " --android-api Tests apps compile and target SDK"
+    echo " --gcloud Tests if gcloud SDK was installed"
     echo " --android-build-tools Used android builds tools"
     echo "  --large-test Run large tests on the image (Firebase Test Lab for example)"
     exit 1
@@ -24,6 +25,7 @@ setup_bundler() {
 while true; do
   case "$1" in
     --android-ndk ) android_ndk=true; shift ;;
+    --gcloud ) gcloud=true; shift ;;
     --android-api ) android_api=$2; shift 2 ;;
     --android-build-tools ) android_build_tools=$2; shift 2 ;;
     --large-test ) large_test=true; shift ;;
@@ -42,8 +44,10 @@ fi
 java -version
 rbenv -v
 
-# Check if gcloud sdk is installed
-gcloud --version
+if [[ "$gcloud" = true ]]; then
+  # Check if gcloud sdk is installed
+  gcloud --version
+fi
 
 # Setup test app environment variables
 export KOTLIN_VERSION="1.3.71"


### PR DESCRIPTION
Google Cloud SDK weights around *0,62 Go* on the expanded image


Using `docker images` locally: 
> The SIZE is the cumulative space taken up by the image and all its parent images. This is also the disk space used by the contents of the Tar file created when you docker save an image.

| REPOSITORY     |      TAG      |           IMAGE ID  |    SIZE |
|----|----|----|----|
| fabernovel/android |   api-29-ndk |          cf1b08589bfb        |     5.22GB |
| fabernovel/android |   api-29-gcloud-ndk |  8061f761b350        |  5.84GB |
| fabernovel/android |  api-29-gcloud      | 085ff6890d3b        |    1.97GB |
| fabernovel/android |  api-29             | 3f129b753e4d           | 1.35GB |