### PR TITLE
Set RBENV_ROOT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,14 +28,14 @@ RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/*
 
 ## Install rbenv
-ENV RBENV_HOME "/root/.rbenv"
-RUN git clone https://github.com/rbenv/rbenv.git $RBENV_HOME
-ENV PATH "$PATH:$RBENV_HOME/bin"
-ENV PATH "$PATH:$RBENV_HOME/shims"
+ENV RBENV_ROOT "/root/.rbenv"
+RUN git clone https://github.com/rbenv/rbenv.git $RBENV_ROOT
+ENV PATH "$PATH:$RBENV_ROOT/bin"
+ENV PATH "$PATH:$RBENV_ROOT/shims"
 
 # Install ruby-build (rbenv plugin)
-RUN mkdir -p "$RBENV_HOME"/plugins
-RUN git clone https://github.com/rbenv/ruby-build.git "$RBENV_HOME"/plugins/ruby-build
+RUN mkdir -p "$RBENV_ROOT"/plugins
+RUN git clone https://github.com/rbenv/ruby-build.git "$RBENV_ROOT"/plugins/ruby-build
 
 # Install default ruby env
 RUN echo “install: --no-document” > ~/.gemrc

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -46,6 +46,12 @@ fi
 if [ "$check_base_tools" = true ]; then
   java -version
   rbenv -v
+  # if HOME is changed, rbenv should still have access to the install plugin
+  (
+    # Changing HOME environment variable in this subshell
+    export HOME="/tmp"
+    rbenv install --skip-existing 2.7.0
+  )
   ssh -V
 fi
 


### PR DESCRIPTION
fix #80 

In the [Dockerfile](https://github.com/faberNovel/docker-android/blob/develop/Dockerfile), `RBENV_HOME` was set instead of `RBENV_ROOT`. By default, rbenv uses "$HOME/.rbenv". 
Github Actions changes $HOME thus rbenv wasn't able to access our setup.  

A test was added to ensure the fix works. 