### PR TITLE
Add setup-ruby support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   ssh \
   # Fastlane plugins dependencies
   # - fastlane-plugin-badge (curb)
-  libcurl4 libcurl4-openssl-dev
+  libcurl4 libcurl4-openssl-dev \
+  # ruby-setup dependencies
+  libyaml-0-2 \
+  libgmp-dev
 
 ## Setup minimal SSH for Github
 RUN mkdir -p $HOME/.ssh

--- a/README.md
+++ b/README.md
@@ -71,13 +71,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2.1.0
 
-    - name: Ruby cache
-      uses: actions/cache@v1.2.0
+    - name: Ruby Setup
+      uses: ruby/setup-ruby@v1
       with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
+        bundler-cache: true
+      env:
+        ImageOS: ubuntu20
 
     - name: Gradle cache
       uses: actions/cache@v1.2.0
@@ -86,11 +85,6 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: |
           ${{ runner.os }}-gradle
-
-    - name: Bundle install
-      run: |
-        bundle config path vendor/bundle
-        bundle check || bundle install
 
     - name: Fastlane
       run: bundle exec fastlane my_lane


### PR DESCRIPTION
As described [by the documentation of actions/cache](https://github.com/actions/cache/blob/main/examples.md#ruby---bundler), it is strongly recommended to use the [setup-ruby](https://github.com/ruby/setup-ruby) action to have a working cache for ruby/bundler.

This is something that I noticed on projects that uses ruby (and fastlane) : most of the time the cache is not hit and bundler is downloading and installing the dependencies again and again and again.

~~Because `setup-ruby` also downloads and install a precompiled ruby runtime, I have removed the ruby runtime from the docker image, because it will be unused. This is breaking change and can be discussed : maybe we should keep it for developers that will not use the `setup-ruby` action ?~~
EDIT : Let's keep the ruby runtime for now (retrocompatibility issues)

From experience `setup-ruby` is pretty fast : it takes <10sec to download and install the ruby runtime and restore the cache