### PR TITLE
Setup minimal SSH configuration for Github

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,11 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   # - fastlane-plugin-badge (curb)
   libcurl4 libcurl4-openssl-dev
 
+## Setup minimal SSH for Github
+RUN mkdir -p $HOME/.ssh
+RUN echo "Host github.com" >> $HOME/.ssh/config
+RUN echo "UpdateHostKeys yes" >> $HOME/.ssh/config
+
 ## Clean dependencies
 RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Default SSH config looks like this : 

`Host vs-ssh.visualstudio.com
    User git
    PubkeyAcceptedAlgorithms +ssh-rsa
    HostkeyAlgorithms +ssh-rsa
Host github.com
UpdateHostKeys yes`

Accepted algorithm for VS SSH host causes failure during SSH interactions with Github repository. This PR simplify config file with minimal options just for github.com.