### PR TITLE
Added openjdk-17-jdk to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV LANG=en_US.UTF-8
 
 ## Install dependencies
 RUN apt-get update && apt-get install --no-install-recommends -y \
+  openjdk-17-jdk \
   openjdk-11-jdk \
   openjdk-8-jdk \
   git \
@@ -49,6 +50,7 @@ RUN mkdir $JENV_ROOT/versions
 ENV JDK_ROOT "/usr/lib/jvm/"
 RUN jenv add ${JDK_ROOT}/java-8-openjdk-amd64
 RUN jenv add ${JDK_ROOT}/java-11-openjdk-amd64
+RUN jenv add ${JDK_ROOT}/java-17-openjdk-amd64
 RUN echo 'export PATH="$JENV_ROOT/bin:$PATH"' >> ~/.bashrc
 RUN echo 'eval "$(jenv init -)"' >> ~/.bashrc
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ keep track of missing native libraries and add them to the next image version.
 
 ## JDK support
 Images support multiple JDK, using [Jenv](https://www.jenv.be/).
-The default JDK is JDK 11, but JDK 8 is also supported for Android API 30 or lower (use `jenv global 1.8`).
+The default JDK is JDK 17, but JDK 11 and 8 are also supported (i.e. use `jenv global 1.8` to set JDK to verion 8).
 To choose a JDK, make sure the script executes on a bash shell, then use Jenv to set the desired version: 
 ```
 jobs:

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -56,15 +56,15 @@ if [ "$gcloud" = true ]; then
 fi
 
 # Setup test app environment variables
-export KOTLIN_VERSION="1.3.71"
-export GRADLE_VERSION="7.3"
-export ANDROID_GRADLE_TOOLS_VERSION="7.0.3"
+export KOTLIN_VERSION="1.9.10"
+export GRADLE_VERSION="8.3"
+export ANDROID_GRADLE_TOOLS_VERSION="8.1.1"
 export COMPILE_SDK_VERSION="$android_api"
 export BUILD_TOOLS_VERSION="$android_build_tools"
 export MIN_SDK_VERSION=21
 export TARGET_SDK_VERSION="$android_api"
 export NDK_VERSION="21.0.6113669"
-jenv global 11
+jenv global 17
 
 setup_gradle_version() {
   if grep -q "distributionUrl" ./gradle/wrapper/gradle-wrapper.properties; then
@@ -112,7 +112,7 @@ if (( "$android_api" < 31 )); then
   jenv global 1.8
   exec_test "$script_path"/test-app-jdk-8
 
-  jenv global 11
+  jenv global 17
 fi
 
 exit 0

--- a/tests/test-app/app/build.gradle
+++ b/tests/test-app/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
+    namespace 'com.fabernovel.testapp'
     compileSdkVersion System.getenv("COMPILE_SDK_VERSION") as Integer
     buildToolsVersion System.getenv("BUILD_TOOLS_VERSION")
 
@@ -16,11 +16,23 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    buildFeatures {
+        viewBinding true
+    }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
     }
 
 }

--- a/tests/test-app/app/src/main/AndroidManifest.xml
+++ b/tests/test-app/app/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.fabernovel.testapp"
-    >
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
Hello everyone!
Thank you so much for providing us this awesome project.

As already mentioned [here](https://github.com/faberNovel/docker-android/issues/120) by other users, right now there's no way to use docker-android images with projects created with Android Studio Flamingo. 

Basically, the problem is related to Gradle 8 which needs Java 17 to work, so I took the chance to edit the script a little bit (I also needed to migrate the project in the tests to make them succeed) and it's working as expected by running

`./ci_cd.sh --android-api 33 --build-tools "33.0.1" --build --test `

I changed most of the files and I also updated the README, but feel free to request changes if you think more tests need to be added and/or other files need to be touched.

Many thanks!