### PR TITLE
README: fix Docker Hub reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ jobs:
 ```
 
 ## 📦 Container Registry
-docker-android images are hosted on [DockerHub](https://hub.docker.com/repository/docker/fabernovel/android).
+docker-android images are hosted on [DockerHub](https://hub.docker.com/r/fabernovel/android).
 
 ## 🔤 Naming
 We provide stable and snapshot variants for latest Android API levels, including or not native SDK.


### PR DESCRIPTION
The existing approach gives me a login screen, so I believe that URL no longer works.