### PR TITLE
Add curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   openjdk-11-jdk \
   openjdk-8-jdk \
   git \
+  curl \
   wget \
   build-essential \
   zlib1g-dev \


### PR DESCRIPTION
Build scripts often download things with curl. `wget` is available, so why not curl :)