### PR TITLE
fix: Quotes in echo command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN mkdir -p "$RBENV_ROOT"/plugins
 RUN git clone https://github.com/rbenv/ruby-build.git "$RBENV_ROOT"/plugins/ruby-build
 
 # Install ruby envs
-RUN echo “install: --no-document” > ~/.gemrc
+RUN echo "install: --no-document" > ~/.gemrc
 ENV RUBY_CONFIGURE_OPTS=--disable-install-doc
 RUN rbenv install 3.1.1
 RUN rbenv install 2.7.1


### PR DESCRIPTION
The `echo` command was using the [Left Double Quotation Mark](https://www.compart.com/en/unicode/U+201C) and [Right Double Quotation Mark](https://www.compart.com/en/unicode/U+201D) instead of the standard [Quotation Mark](https://www.compart.com/en/unicode/U+0022). This might lead to problems later on.

This PR replaces the quotes with the standard quotes.