### PR TITLE
feat: Add $rbenv_root as build argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/*
 
 ## Install rbenv
-ENV RBENV_ROOT "/root/.rbenv"
+ARG rbenv_root="/root/.rbenv"
+ENV RBENV_ROOT "${rbenv_root}"
 RUN git clone https://github.com/rbenv/rbenv.git $RBENV_ROOT
 ENV PATH "$PATH:$RBENV_ROOT/bin"
 ENV PATH "$PATH:$RBENV_ROOT/shims"


### PR DESCRIPTION
Currently, the environment variable `RBENV_ROOT` is not configurable during build. This might lead to problems on Docker instances where `/root` is not accessable.

This PR adds `$rbenv_root` as build argument which configures the `RBENV_ROOT` environment variable.