### PR TITLE
Update Ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:latest
 
 # Required for Jenv
 SHELL ["/bin/bash", "-c"]

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ on:
 
 jobs:
   my_android_job:
-    runs-on: ubuntu-22.04 # Works also with self hosted runner supporting docker
+    runs-on: ubuntu-24.04 # Works also with self hosted runner supporting docker
     container:
       image: docker://fabernovel/android:api-29-v1.1.0
 
@@ -76,7 +76,7 @@ jobs:
       with:
         bundler-cache: true
       env:
-        ImageOS: ubuntu20
+        ImageOS: ubuntu24
 
     - name: Gradle cache
       uses: actions/cache@v3
@@ -105,7 +105,7 @@ on:
 
 jobs:
   my_android_job:
-    runs-on: ubuntu-22.04 # Works also with self hosted runner supporting docker
+    runs-on: ubuntu-24.04 # Works also with self hosted runner supporting docker
 
   steps:
     - name: Checkout


### PR DESCRIPTION
Ubuntu 20.04 is no longer supported. So I propose we move to ubuntu latest (which points to latest LTS). This way we will avoid issues with support in the future. 